### PR TITLE
Fix release build: ungate hosted UI-inspection adapter

### DIFF
--- a/apps/Donkey/Sources/DonkeyAI/DebugUIInspectionHostedAdapter.swift
+++ b/apps/Donkey/Sources/DonkeyAI/DebugUIInspectionHostedAdapter.swift
@@ -1,5 +1,3 @@
-#if DONKEY_DEBUG_OVERLAY
-
 import DonkeyContracts
 import Foundation
 
@@ -442,5 +440,3 @@ private struct RawDebugUICoordinateSpace: Decodable {
     var width: Double
     var height: Double
 }
-
-#endif


### PR DESCRIPTION
The nightly (release) build failed with `cannot find 'DebugUIInspectionResponseDecoder' / 'DebugUIInspectionRequest' / 'DebugUIInspectionAnalyzing' in scope` because `DebugUIInspectionHostedAdapter.swift` was wrapped in `#if DONKEY_DEBUG_OVERLAY`, a flag only defined for debug configurations. The production vision planners (`VisionActionPlanner`, `GeminiVertexVisionPlanner`, `GeminiVertexVisionBoxPlanner`, `VisionGroundingFlow`) reference those types unconditionally, so they were missing in release. This removes the compile gate; all of the adapter's dependencies live in non-gated files, so it's safe, and a `swift build -c release --target DonkeyAI` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)