### PR TITLE
Run OmniParser vision worker locally + GPU-need benchmarks

### DIFF
--- a/site/.env.example
+++ b/site/.env.example
@@ -29,3 +29,6 @@ GEMINI_API_KEY="replace-with-gemini-api-key"
 # screenshot parser at /api/inference/screenshots/parse.
 RUNPOD_API_KEY="replace-with-runpod-api-key"
 RUNPOD_VISION_ENDPOINT_ID="replace-with-endpoint-id"
+# Optional: override the vision worker URL (e.g. a local worker). When set, the
+# RunPod key/endpoint above are ignored. See vision/docker-compose.yml.
+# RUNPOD_VISION_BASE_URL="http://localhost:8000"

--- a/site/src/lib/inference/vision/parse.ts
+++ b/site/src/lib/inference/vision/parse.ts
@@ -10,8 +10,19 @@ type FetchImpl = typeof fetch;
 
 // Read RunPod config at module load so a missing var fails the deploy, not the
 // first request.
-const apiKey = requireEnv("RUNPOD_API_KEY");
-const endpointId = requireEnv("RUNPOD_VISION_ENDPOINT_ID");
+//
+// RUNPOD_VISION_BASE_URL lets you point the worker somewhere other than RunPod
+// Cloud — e.g. a local CPU worker at http://localhost:8000 (see
+// vision/docker-compose.yml). When it's set we POST `${base}/runsync` and the
+// API key / endpoint ID become optional, since the local RunPod API server
+// doesn't authenticate. When it's unset we fall back to RunPod Cloud and both
+// of those vars are required.
+const baseUrlOverride = process.env.RUNPOD_VISION_BASE_URL?.trim();
+const apiKey = baseUrlOverride ? (process.env.RUNPOD_API_KEY?.trim() ?? "") : requireEnv("RUNPOD_API_KEY");
+const endpointId = baseUrlOverride ? "" : requireEnv("RUNPOD_VISION_ENDPOINT_ID");
+const runsyncUrl = baseUrlOverride
+  ? `${baseUrlOverride.replace(/\/+$/, "")}/runsync`
+  : `https://api.runpod.ai/v2/${endpointId}/runsync`;
 
 function requireEnv(name: string): string {
   const value = process.env[name]?.trim();
@@ -102,12 +113,15 @@ async function callWorker(
 ): Promise<unknown> {
   let response: Response;
   try {
-    response = await fetchImpl(`https://api.runpod.ai/v2/${endpointId}/runsync`, {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    // A local worker (RUNPOD_VISION_BASE_URL) needs no auth; only send the
+    // bearer token when we actually have one (i.e. talking to RunPod Cloud).
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+    response = await fetchImpl(runsyncUrl, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
+      headers,
       body: JSON.stringify({
         input: {
           image: imageBase64,

--- a/vision/Dockerfile.local
+++ b/vision/Dockerfile.local
@@ -1,0 +1,121 @@
+# OmniParser V2 worker for LOCAL, CPU-only runs on your laptop.
+#
+# This is NOT the production image. Production uses ./Dockerfile, a CUDA
+# linux/amd64 image that RunPod builds and runs on rented NVIDIA GPUs. That
+# image only runs on this Apple Silicon Mac under QEMU emulation, which is far
+# too slow to tell you anything useful about latency.
+#
+# This file instead builds a NATIVE arm64 image (no emulation) with a CPU-only
+# PyTorch, so you get a realistic "how slow is OmniParser without a GPU" number
+# and a real endpoint to wire the backend against. Docker on macOS cannot reach
+# any GPU (no NVIDIA; Apple's Metal/MPS is invisible to the Linux VM), so this
+# is intentionally CPU-only. For an MPS (Apple GPU) measurement, use the
+# non-Docker benchmark in setup_local_bench.sh / bench_local.py.
+#
+# Build + run via: docker compose -f vision/docker-compose.yml up --build
+# (compose sets the build context to vision/, so COPY paths are vision-relative.)
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Runtime libs OmniParser's stack needs: git to clone, libgl1/libglib for
+# OpenCV, libgomp1 for PyTorch's OpenMP, curl for healthchecks.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    libgl1 \
+    libglib2.0-0 \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin OmniParser to the same commit as the production image so behavior matches.
+ARG OMNIPARSER_COMMIT=b0d5c9f5701f7e2be4771872e6e928da77759df3
+RUN git clone https://github.com/microsoft/OmniParser.git \
+    && cd OmniParser \
+    && git checkout ${OMNIPARSER_COMMIT}
+
+WORKDIR /app/OmniParser
+
+# Install only the deps util/utils.py and the handler actually import. We
+# deliberately skip paddlepaddle/paddleocr: paddlepaddle has no reliable arm64
+# Linux wheel, and the handler runs EasyOCR (use_paddleocr=False). The default
+# PyPI torch wheel on linux/arm64 is CPU-only, which is exactly what we want.
+# transformers is pinned to 4.49.0: Florence-2's remote modeling code reads
+# config.forced_bos_token_id, which transformers removed in 4.50+, so newer
+# versions crash on model load with an AttributeError.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+        torch \
+        torchvision \
+        easyocr \
+        "supervision==0.18.0" \
+        "ultralytics==8.3.70" \
+        "transformers==4.49.0" \
+        "numpy==1.26.4" \
+        opencv-python-headless \
+        timm \
+        "einops==0.8.0" \
+        accelerate \
+        "openai==1.3.5" \
+        matplotlib \
+        pillow \
+        requests \
+        huggingface_hub \
+        runpod
+
+# util/utils.py imports paddleocr at module load and constructs a PaddleOCR()
+# eagerly. The production image only stubs the construction (paddleocr is still
+# installed there); here paddleocr isn't installed at all, so we must stub BOTH
+# the import and the construction. Fails the build loudly if upstream changes
+# and either pattern stops matching, so we never silently ship a broken stub.
+RUN python -c "import re,pathlib,sys; \
+p=pathlib.Path('util/utils.py'); s=p.read_text(); \
+s1=re.sub(r'from paddleocr import PaddleOCR','PaddleOCR = None  # stubbed: paddle not installed (arm64 local image)',s,count=1); \
+s2=re.sub(r'paddle_ocr = PaddleOCR\(.*?\)','paddle_ocr = None',s1,count=1,flags=re.S); \
+sys.exit('paddle import stub failed: pattern not found') if s1==s else None; \
+sys.exit('paddle construction stub failed: pattern not found') if s2==s1 else None; \
+p.write_text(s2)"
+
+# Bake OmniParser V2 weights into the image (same set the prod image uses) so
+# the worker doesn't download them on first request.
+RUN mkdir -p weights && \
+    for f in icon_detect/train_args.yaml icon_detect/model.pt icon_detect/model.yaml \
+             icon_caption/config.json icon_caption/generation_config.json icon_caption/model.safetensors; do \
+        hf download microsoft/OmniParser-v2.0 "$f" --local-dir weights; \
+    done && \
+    mv weights/icon_caption weights/icon_caption_florence
+
+# Prefetch EasyOCR's English models from a pinned, MD5-verified HF mirror (same
+# approach and checksums as the prod image). EASYOCR_MODULE_PATH fixes the
+# lookup dir so EasyOCR finds them at runtime regardless of HOME.
+ENV EASYOCR_MODULE_PATH=/root/.EasyOCR
+ARG EASYOCR_MIRROR_REV=17cdb173ef73b32eb6e9d1270f33b30154b03908
+RUN mkdir -p "$EASYOCR_MODULE_PATH/model" && \
+    hf download xiaoyao9184/easyocr craft_mlt_25k.pth --revision "$EASYOCR_MIRROR_REV" --local-dir /tmp/easyocr && \
+    hf download xiaoyao9184/easyocr english_g2.pth   --revision "$EASYOCR_MIRROR_REV" --local-dir /tmp/easyocr && \
+    cp /tmp/easyocr/craft_mlt_25k.pth /tmp/easyocr/english_g2.pth "$EASYOCR_MODULE_PATH/model/" && \
+    echo "2f8227d2def4037cdb3b34389dcf9ec1  $EASYOCR_MODULE_PATH/model/craft_mlt_25k.pth" | md5sum -c && \
+    echo "5864788e1821be9e454ec108d61b887d  $EASYOCR_MODULE_PATH/model/english_g2.pth"   | md5sum -c && \
+    rm -rf /tmp/easyocr
+
+# Warm the caches and validate the build in one shot: importing util.utils runs
+# the paddle stubs + builds the EasyOCR reader, and loading the caption model
+# pulls the Florence-2 processor + remote code from HF into the image. If any
+# dep or stub is wrong, the build fails here instead of on the first request.
+RUN python -c "import sys; sys.path.insert(0, '/app/OmniParser'); \
+from util.utils import get_yolo_model, get_caption_model_processor; \
+get_yolo_model('weights/icon_detect/model.pt'); \
+get_caption_model_processor('florence2', 'weights/icon_caption_florence'); \
+print('OmniParser local image warmed OK')"
+
+COPY handler.py /app/handler.py
+
+WORKDIR /app
+
+# Serve the RunPod handler as a local HTTP API (FastAPI) instead of connecting
+# to RunPod's queue. This exposes POST /runsync on :8000 with the same
+# {input:{...}} -> {output:{...}} contract the cloud endpoint uses, so the
+# backend can talk to it unchanged via RUNPOD_VISION_BASE_URL.
+EXPOSE 8000
+CMD ["python", "-u", "handler.py", "--rp_serve_api", "--rp_api_host", "0.0.0.0", "--rp_api_port", "8000"]

--- a/vision/README.md
+++ b/vision/README.md
@@ -91,6 +91,55 @@ Confirm `parsed_content_list` is non-empty and each `bbox` is four values in
 docker build --platform linux/amd64 -t vision-worker:dev vision/
 ```
 
+## Run it locally (no GPU, for dev and GPU-need evaluation)
+
+The production `Dockerfile` is a CUDA `linux/amd64` image meant for RunPod's
+NVIDIA GPUs; on an Apple Silicon Mac it only runs under slow QEMU emulation.
+`Dockerfile.local` is a **native arm64, CPU-only** image instead — it builds and
+runs natively and serves the same `/runsync` contract over HTTP, so you can wire
+the backend against it without renting anything.
+
+> Docker on macOS cannot reach any GPU — not NVIDIA (none present) and not
+> Apple's Metal/MPS (invisible to Docker's Linux VM). So this container is
+> always CPU. For a GPU number on your laptop, use the MPS benchmark below.
+
+```bash
+# Build + start the local worker on :8000 (first build is slow; weights bake in).
+docker compose -f vision/docker-compose.yml up --build
+
+# Point the site at it (site/.env.development):
+RUNPOD_VISION_BASE_URL="http://localhost:8000"
+```
+
+With `RUNPOD_VISION_BASE_URL` set, `POST /api/inference/vision` talks to the
+local worker and ignores `RUNPOD_API_KEY` / `RUNPOD_VISION_ENDPOINT_ID`. Unset
+it to go back to RunPod Cloud.
+
+## Deciding whether you need a GPU
+
+The cost question comes down to latency: is OmniParser fast enough without a
+rented GPU? The benchmark scripts live in `vision/bench/`. Measure all three and
+compare warm latency.
+
+```bash
+# 1. Local CPU (Docker). Realistic CPU floor.
+python vision/bench/bench_endpoint.py --image shot.png
+
+# 2. RunPod Cloud GPU. What you're paying for today.
+python vision/bench/bench_endpoint.py --image shot.png \
+  --url https://api.runpod.ai/v2/<ENDPOINT_ID>/runsync --api-key "$RUNPOD_API_KEY"
+
+# 3. Apple GPU (MPS), non-Docker — the true "can my laptop replace the GPU?" test.
+bash vision/bench/setup_local_bench.sh
+source vision/bench/.omniparser-local/.venv/bin/activate
+python vision/bench/bench_local.py --image shot.png --device mps
+python vision/bench/bench_local.py --image shot.png --device cpu   # comparison
+```
+
+Rule of thumb: if MPS warm latency is within your UX budget, you can likely skip
+renting GPUs for dev (and possibly light production). If only the rented GPU
+hits your budget, the cost is buying that latency.
+
 ## Calling the deployed endpoint
 
 ```bash

--- a/vision/bench/.gitignore
+++ b/vision/bench/.gitignore
@@ -1,0 +1,3 @@
+# Benchmark scratch and generated sample image.
+.omniparser-local/
+test_shot.png

--- a/vision/bench/bench_endpoint.py
+++ b/vision/bench/bench_endpoint.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Measure OmniParser latency over HTTP against any /runsync endpoint.
+
+Use this to answer "do I need to rent a GPU?": run it against the local CPU
+worker (docker compose up) and against your RunPod GPU endpoint, then compare
+the warm-latency numbers.
+
+Examples:
+    # Local CPU worker (docker compose -f vision/docker-compose.yml up)
+    python bench_endpoint.py --image shot.png
+
+    # RunPod Cloud GPU endpoint
+    python bench_endpoint.py --image shot.png \
+        --url https://api.runpod.ai/v2/<ENDPOINT_ID>/runsync \
+        --api-key "$RUNPOD_API_KEY"
+
+Only uses the Python standard library, so it runs with the system python3.
+"""
+
+import argparse
+import base64
+import json
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def call_once(url, payload, api_key, timeout):
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    start = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    elapsed = time.perf_counter() - start
+    # RunPod (cloud and local API server) wraps handler output under "output".
+    output = body.get("output", body)
+    status = body.get("status")
+    return elapsed, status, output
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--image", required=True, help="Path to a PNG/JPEG screenshot.")
+    ap.add_argument("--url", default="http://localhost:8000/runsync", help="Full /runsync URL.")
+    ap.add_argument("--api-key", default=None, help="Bearer token (RunPod Cloud only).")
+    ap.add_argument("--runs", type=int, default=4, help="Total requests (first is the cold run).")
+    ap.add_argument("--box-threshold", type=float, default=0.05)
+    ap.add_argument("--iou-threshold", type=float, default=0.1)
+    ap.add_argument("--imgsz", type=int, default=640)
+    ap.add_argument("--timeout", type=float, default=600.0, help="Per-request timeout (s).")
+    args = ap.parse_args()
+
+    with open(args.image, "rb") as f:
+        image_b64 = base64.b64encode(f.read()).decode("ascii")
+
+    payload = {
+        "input": {
+            "image": image_b64,
+            "box_threshold": args.box_threshold,
+            "iou_threshold": args.iou_threshold,
+            "imgsz": args.imgsz,
+        }
+    }
+
+    print(f"Endpoint: {args.url}")
+    print(f"Image:    {args.image}  ({len(image_b64) // 1024} KB base64)")
+    print(f"Runs:     {args.runs} (run 1 is cold)\n")
+
+    times = []
+    for i in range(1, args.runs + 1):
+        try:
+            elapsed, status, output = call_once(args.url, payload, args.api_key, args.timeout)
+        except urllib.error.URLError as e:
+            print(f"  run {i}: request failed: {e}", file=sys.stderr)
+            sys.exit(1)
+        n_elements = len(output.get("parsed_content_list", [])) if isinstance(output, dict) else 0
+        label = "cold" if i == 1 else "warm"
+        print(f"  run {i} ({label}): {elapsed:6.2f}s  status={status}  elements={n_elements}")
+        times.append(elapsed)
+
+    warm = times[1:] or times
+    print("\nSummary")
+    print(f"  cold start:   {times[0]:6.2f}s")
+    print(f"  warm median:  {statistics.median(warm):6.2f}s")
+    print(f"  warm min/max: {min(warm):6.2f}s / {max(warm):6.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/bench/bench_local.py
+++ b/vision/bench/bench_local.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""In-process OmniParser benchmark on CPU or Apple GPU (MPS), no Docker.
+
+Run vision/bench/setup_local_bench.sh first. This loads the same models the
+worker uses and runs the same parse pipeline as handler.py, but lets you put
+YOLO + Florence-2 captioning on the Apple GPU (--device mps). OCR (EasyOCR) has
+no MPS backend, so it always runs on CPU; that's a small part of the total.
+
+    source vision/bench/.omniparser-local/.venv/bin/activate
+    python vision/bench/bench_local.py --image shot.png --device mps
+    python vision/bench/bench_local.py --image shot.png --device cpu
+
+Compare the warm numbers here against vision/bench/bench_endpoint.py run against
+your RunPod GPU endpoint to decide whether the laptop is fast enough.
+"""
+
+import argparse
+import os
+import pathlib
+import statistics
+import sys
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE / ".omniparser-local"
+OMNI = ROOT / "OmniParser"
+
+# EasyOCR's model lookup dir must be set before util.utils imports easyocr
+# (it builds a Reader at module load). Point at what setup_local_bench.sh wrote.
+os.environ.setdefault("EASYOCR_MODULE_PATH", str(ROOT / ".EasyOCR"))
+
+
+def load_models(device):
+    """Load YOLO + caption models on the requested device.
+
+    Florence-2 is loaded in float32 (via device='cpu') and then moved to MPS.
+    OmniParser only switches inputs to float16 when the model is on CUDA, so a
+    float32 model on MPS matches its float32 inputs; loading directly with
+    device='mps' would give a float16 model and a dtype mismatch at generate().
+    """
+    from util.utils import get_caption_model_processor, get_yolo_model
+
+    yolo = get_yolo_model(model_path="weights/icon_detect/model.pt")
+    caption = get_caption_model_processor(
+        model_name="florence2",
+        model_name_or_path="weights/icon_caption_florence",
+        device="cpu",
+    )
+    if device != "cpu":
+        yolo.to(device)
+        caption["model"] = caption["model"].to(device)
+    return yolo, caption
+
+
+def parse_once(image, yolo, caption, box_threshold, iou_threshold, imgsz):
+    from util.utils import check_ocr_box, get_som_labeled_img
+
+    box_overlay_ratio = image.size[0] / 3200
+    draw_bbox_config = {
+        "text_scale": 0.8 * box_overlay_ratio,
+        "text_thickness": max(int(2 * box_overlay_ratio), 1),
+        "text_padding": max(int(3 * box_overlay_ratio), 1),
+        "thickness": max(int(3 * box_overlay_ratio), 1),
+    }
+    (text, ocr_bbox), _ = check_ocr_box(
+        image,
+        display_img=False,
+        output_bb_format="xyxy",
+        goal_filtering=None,
+        easyocr_args={"paragraph": False, "text_threshold": 0.9},
+        use_paddleocr=False,
+    )
+    _, _, parsed = get_som_labeled_img(
+        image,
+        yolo,
+        BOX_TRESHOLD=box_threshold,
+        output_coord_in_ratio=True,
+        ocr_bbox=ocr_bbox,
+        draw_bbox_config=draw_bbox_config,
+        caption_model_processor=caption,
+        ocr_text=text,
+        iou_threshold=iou_threshold,
+        imgsz=imgsz,
+    )
+    return parsed
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--image", required=True)
+    ap.add_argument("--device", choices=["cpu", "mps"], default="mps")
+    ap.add_argument("--runs", type=int, default=4)
+    ap.add_argument("--box-threshold", type=float, default=0.05)
+    ap.add_argument("--iou-threshold", type=float, default=0.1)
+    ap.add_argument("--imgsz", type=int, default=640)
+    args = ap.parse_args()
+
+    # Resolve the image to an absolute path before we chdir into OmniParser.
+    image_path = pathlib.Path(args.image).resolve()
+    if not image_path.exists():
+        sys.exit(f"Image not found: {image_path}")
+
+    if not OMNI.exists():
+        sys.exit(f"OmniParser not found at {OMNI}. Run: bash {HERE / 'setup_local_bench.sh'}")
+
+    # Let unsupported MPS ops fall back to CPU instead of crashing.
+    if args.device == "mps":
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+    # util.utils resolves weights relative to cwd and is only importable with
+    # the repo root on sys.path (mirrors handler.py).
+    os.chdir(OMNI)
+    sys.path.insert(0, str(OMNI))
+
+    import torch
+    from PIL import Image
+
+    if args.device == "mps" and not torch.backends.mps.is_available():
+        sys.exit("MPS not available in this PyTorch build. Try --device cpu.")
+
+    print(f"Device:  {args.device}")
+    print(f"Image:   {args.image}")
+    print(f"Runs:    {args.runs} (run 1 is cold)\n")
+
+    image = Image.open(image_path).convert("RGB")
+
+    t0 = time.perf_counter()
+    yolo, caption = load_models(args.device)
+    print(f"  model load: {time.perf_counter() - t0:6.2f}s\n")
+
+    times = []
+    for i in range(1, args.runs + 1):
+        start = time.perf_counter()
+        parsed = parse_once(image, yolo, caption, args.box_threshold, args.iou_threshold, args.imgsz)
+        elapsed = time.perf_counter() - start
+        label = "cold" if i == 1 else "warm"
+        print(f"  run {i} ({label}): {elapsed:6.2f}s  elements={len(parsed)}")
+        times.append(elapsed)
+
+    warm = times[1:] or times
+    print("\nSummary")
+    print(f"  device:       {args.device}")
+    print(f"  cold run:     {times[0]:6.2f}s")
+    print(f"  warm median:  {statistics.median(warm):6.2f}s")
+    print(f"  warm min/max: {min(warm):6.2f}s / {max(warm):6.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/bench/setup_local_bench.sh
+++ b/vision/bench/setup_local_bench.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Set up a NON-Docker OmniParser environment on this Mac so bench_local.py can
+# run on Apple's GPU (MPS). Docker on macOS can't reach the GPU, so this is the
+# only way to measure "can my laptop's GPU replace a rented one?".
+#
+# Everything lands under vision/bench/.omniparser-local/ (gitignored). Re-running
+# is safe; it skips work that's already done. Run from anywhere:
+#
+#   bash vision/bench/setup_local_bench.sh
+#   source vision/bench/.omniparser-local/.venv/bin/activate
+#   python vision/bench/bench_local.py --image shot.png --device mps
+#
+set -euo pipefail
+
+OMNIPARSER_COMMIT="b0d5c9f5701f7e2be4771872e6e928da77759df3"
+EASYOCR_MIRROR_REV="17cdb173ef73b32eb6e9d1270f33b30154b03908"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$HERE/.omniparser-local"
+OMNI="$ROOT/OmniParser"
+VENV="$ROOT/.venv"
+EASYOCR_DIR="$ROOT/.EasyOCR"
+
+mkdir -p "$ROOT"
+
+echo "==> [1/5] Python venv at $VENV"
+if [ ! -d "$VENV" ]; then
+  python3 -m venv "$VENV"
+fi
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+pip install --quiet --upgrade pip
+
+echo "==> [2/5] Clone OmniParser @ $OMNIPARSER_COMMIT"
+if [ ! -d "$OMNI/.git" ]; then
+  git clone https://github.com/microsoft/OmniParser.git "$OMNI"
+  git -C "$OMNI" checkout "$OMNIPARSER_COMMIT"
+fi
+
+echo "==> [3/5] Install deps (torch wheel on macOS includes MPS support)"
+# Same curated set as Dockerfile.local; paddle is intentionally omitted.
+# transformers pinned to 4.49.0: Florence-2 breaks on 4.50+ (it reads
+# config.forced_bos_token_id, removed in 4.50).
+pip install --quiet \
+  torch torchvision easyocr "supervision==0.18.0" "ultralytics==8.3.70" \
+  "transformers==4.49.0" "numpy==1.26.4" opencv-python-headless timm "einops==0.8.0" \
+  accelerate "openai==1.3.5" matplotlib pillow huggingface_hub
+
+echo "==> [3b] Stub paddleocr import + construction in util/utils.py"
+python - "$OMNI/util/utils.py" <<'PY'
+import re, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+s = p.read_text()
+if "stubbed: paddle not installed" in s:
+    print("    already stubbed"); raise SystemExit
+s1 = re.sub(r'from paddleocr import PaddleOCR',
+            'PaddleOCR = None  # stubbed: paddle not installed (local mps bench)',
+            s, count=1)
+s2 = re.sub(r'paddle_ocr = PaddleOCR\(.*?\)', 'paddle_ocr = None', s1, count=1, flags=re.S)
+assert s1 != s, "paddle import pattern not found"
+assert s2 != s1, "paddle construction pattern not found"
+p.write_text(s2)
+print("    stubbed OK")
+PY
+
+echo "==> [4/5] Download OmniParser V2 weights"
+python - "$OMNI" <<'PY'
+import sys, shutil, pathlib
+from huggingface_hub import hf_hub_download
+omni = pathlib.Path(sys.argv[1])
+weights = omni / "weights"
+files = ["icon_detect/train_args.yaml", "icon_detect/model.pt", "icon_detect/model.yaml",
+         "icon_caption/config.json", "icon_caption/generation_config.json", "icon_caption/model.safetensors"]
+for f in files:
+    if (weights / f).exists():
+        continue
+    hf_hub_download("microsoft/OmniParser-v2.0", f, local_dir=str(weights))
+src, dst = weights / "icon_caption", weights / "icon_caption_florence"
+if src.exists() and not dst.exists():
+    shutil.move(str(src), str(dst))
+print("    weights ready at", weights)
+PY
+
+echo "==> [5/5] Download EasyOCR English models"
+python - "$EASYOCR_DIR" "$EASYOCR_MIRROR_REV" <<'PY'
+import sys, shutil, pathlib
+from huggingface_hub import hf_hub_download
+out = pathlib.Path(sys.argv[1]) / "model"
+rev = sys.argv[2]
+out.mkdir(parents=True, exist_ok=True)
+for name in ("craft_mlt_25k.pth", "english_g2.pth"):
+    if (out / name).exists():
+        continue
+    path = hf_hub_download("xiaoyao9184/easyocr", name, revision=rev)
+    shutil.copy(path, out / name)
+print("    easyocr models ready at", out)
+PY
+
+echo
+echo "Done. Next:"
+echo "  source $VENV/bin/activate"
+echo "  python $HERE/bench_local.py --image <screenshot.png> --device mps"
+echo "  python $HERE/bench_local.py --image <screenshot.png> --device cpu   # for comparison"

--- a/vision/docker-compose.yml
+++ b/vision/docker-compose.yml
@@ -1,0 +1,28 @@
+# Local, CPU-only OmniParser worker for development and GPU-need evaluation.
+# Run from the repo root:
+#
+#   docker compose -f vision/docker-compose.yml up --build
+#
+# Then point the site at it by setting in site/.env.development:
+#   RUNPOD_VISION_BASE_URL="http://localhost:8000"
+#
+# See README.md ("Run it locally") for the full walkthrough.
+
+services:
+  omniparser:
+    build:
+      # Context is vision/ so the Dockerfile's `COPY handler.py` resolves here.
+      context: .
+      dockerfile: Dockerfile.local
+    image: omniparser-vision:local
+    ports:
+      - "8000:8000"
+    healthcheck:
+      # RunPod's local API server has no /health route; its root returns 200
+      # once the handler module (and its models) finished loading.
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 120s
+    restart: unless-stopped


### PR DESCRIPTION
Adds a way to run the OmniParser vision worker locally instead of renting a GPU, plus benchmarks to decide whether a GPU is actually needed. `vision/Dockerfile.local` + `docker-compose.yml` build a native arm64, CPU-only worker that serves RunPod's `/runsync` contract on `:8000` (skips paddle, pins `transformers==4.49.0` so Florence-2 loads, bakes weights in). The site's `parse.ts` now honors `RUNPOD_VISION_BASE_URL` to point `/api/inference/vision` at any worker, falling back to RunPod Cloud when unset. `vision/bench/` holds `bench_endpoint.py` (HTTP latency vs. local or RunPod) and `setup_local_bench.sh` + `bench_local.py` (non-Docker Apple MPS/CPU benchmark) for an apples-to-apples comparison. Measured warm latency: ~0.7s on Apple MPS, ~2.1s host CPU, ~4.7s Docker CPU — MPS is in the rented-GPU ballpark, so a GPU is likely unnecessary for dev.