### PR TITLE
Advertise full server-side time on donkeyvision

### DIFF
--- a/site/src/app/donkeyvision/data.ts
+++ b/site/src/app/donkeyvision/data.ts
@@ -13,10 +13,10 @@ import type { Feature, Stat } from "@/app/donkeyvision/types";
 
 export const stats: Stat[] = [
   {
-    eyebrow: "On the GPU",
+    eyebrow: "Server-side",
     label:
-      "Server-side time to detect, OCR, and label every element in a screenshot — the part we control.",
-    value: "~0.2s",
+      "Full time on our side to process a screenshot — detect, OCR, and label every element, ready to return. The part we control.",
+    value: "~0.7s",
   },
 ];
 


### PR DESCRIPTION
Switch the donkeyvision headline stat from the ~0.2s parse to the ~0.7s full server-side processing time (decode, detect, OCR, label, encode) — the complete figure for the part we control.