### PR TITLE
Add auth links to landing header/footer and adopt next/link

### DIFF
--- a/docs/guides/frontend-nextjs-guidelines.md
+++ b/docs/guides/frontend-nextjs-guidelines.md
@@ -20,6 +20,12 @@ This guide explains how to work in the `site` app. Keep changes aligned with the
 - Keep secrets and direct database access out of Client Components.
 - Pass plain serializable props from Server Components into Client Components.
 
+## Navigation
+
+- Use the `next/link` `<Link>` component for internal routes (anything starting with `/`) so navigation stays client-side and prefetches.
+- Use a plain `<a>` only for external URLs, `mailto:`, and other non-route links.
+- When a shared control accepts an arbitrary `href` (such as the landing `PillButton`), let the control pick `<Link>` vs `<a>` from the href instead of duplicating that choice at every call site.
+
 ## Styling
 
 - Use Tailwind utilities and existing shared UI components as the default UI language.

--- a/site/src/app/_components/landing/AuthScreen.tsx
+++ b/site/src/app/_components/landing/AuthScreen.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { ArrowRight, ShieldCheck, Sparkles } from "lucide-react";
 import { useCallback, useState } from "react";
 
@@ -90,7 +91,7 @@ export function AuthScreen({ mode }: Props) {
         width: "100%",
       }}
     >
-      <TopNav ctaHref="/pricing" ctaLabel="Pricing" />
+      <TopNav ctaHref="/pricing" ctaLabel="Pricing" showAuthLinks={false} />
       <section
         style={{
           display: "grid",
@@ -197,19 +198,19 @@ export function AuthScreen({ mode }: Props) {
                 }}
               >
                 By continuing, you agree to the{" "}
-                <a
+                <Link
                   href="/terms"
                   style={{ color: BLACK, fontWeight: 600 }}
                 >
                   Terms of Use
-                </a>{" "}
+                </Link>{" "}
                 and{" "}
-                <a
+                <Link
                   href="/privacy"
                   style={{ color: BLACK, fontWeight: 600 }}
                 >
                   Privacy Policy
-                </a>
+                </Link>
                 .
               </p>
               {statusMessage ? (

--- a/site/src/app/_components/landing/Footer.tsx
+++ b/site/src/app/_components/landing/Footer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Link, Play, Send, type LucideIcon } from "lucide-react";
+import { Link as LinkIcon, Play, Send, type LucideIcon } from "lucide-react";
+import Link from "next/link";
 
 import { useMediaQuery } from "@/app/_components/landing/useMediaQuery";
 import { BLACK } from "@/app/_components/landing/theme";
@@ -14,7 +15,7 @@ type SocialLink = {
 export function Footer() {
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const socialLinks: SocialLink[] = [
-    { href: "https://www.linkedin.com", icon: Link, label: "LinkedIn" },
+    { href: "https://www.linkedin.com", icon: LinkIcon, label: "LinkedIn" },
     { href: "https://www.youtube.com", icon: Play, label: "YouTube" },
     { href: "https://twitter.com", icon: Send, label: "Twitter" },
   ];
@@ -91,7 +92,27 @@ export function Footer() {
               gap: 16,
             }}
           >
-            <a
+            <Link
+              href="/sign-in"
+              style={{
+                color: BLACK,
+                fontWeight: 600,
+                textDecoration: "none",
+              }}
+            >
+              Sign in
+            </Link>
+            <Link
+              href="/sign-up"
+              style={{
+                color: BLACK,
+                fontWeight: 600,
+                textDecoration: "none",
+              }}
+            >
+              Sign up
+            </Link>
+            <Link
               href="/privacy"
               style={{
                 color: BLACK,
@@ -100,8 +121,8 @@ export function Footer() {
               }}
             >
               Privacy Policy
-            </a>
-            <a
+            </Link>
+            <Link
               href="/terms"
               style={{
                 color: BLACK,
@@ -110,7 +131,7 @@ export function Footer() {
               }}
             >
               Terms of Use
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/site/src/app/_components/landing/LandingPrimitives.tsx
+++ b/site/src/app/_components/landing/LandingPrimitives.tsx
@@ -1,6 +1,13 @@
+import Link from "next/link";
 import type { CSSProperties, ReactNode } from "react";
 
 import { BLACK, CARD, CORAL, type CardColor } from "@/app/_components/landing/theme";
+
+// Internal routes use next/link for client-side navigation; anything else
+// (http(s), mailto, etc.) falls back to a plain anchor.
+function isInternalHref(href: string) {
+  return href.startsWith("/") && !href.startsWith("//");
+}
 
 type ButtonVariant = "primary" | "dark" | "secondary";
 type ButtonSize = "sm" | "md" | "lg";
@@ -136,6 +143,14 @@ export function PillButton({
   };
 
   if (href && !disabled && !onClick) {
+    if (isInternalHref(href)) {
+      return (
+        <Link aria-label={ariaLabel} href={href} style={sharedStyle}>
+          {children}
+        </Link>
+      );
+    }
+
     return (
       <a aria-label={ariaLabel} href={href} style={sharedStyle}>
         {children}

--- a/site/src/app/_components/landing/TopNav.tsx
+++ b/site/src/app/_components/landing/TopNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 
 import { PillButton } from "@/app/_components/landing/LandingPrimitives";
@@ -14,12 +15,14 @@ type Props = {
   ctaHref?: string;
   ctaLabel?: string;
   homeHref?: string;
+  showAuthLinks?: boolean;
 };
 
 export function TopNav({
   ctaHref = DONKEY_INSTALL_URL,
   ctaLabel = "Download",
   homeHref = "/",
+  showAuthLinks = true,
 }: Props) {
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
@@ -36,7 +39,7 @@ export function TopNav({
         width: "100%",
       }}
     >
-      <a
+      <Link
         href={homeHref}
         style={{
           display: "flex",
@@ -72,10 +75,33 @@ export function TopNav({
           />
         </div>
         <span style={{ fontWeight: 600, fontSize: 24 }}>donkey</span>
-      </a>
-      <PillButton href={ctaHref} variant="dark" size="sm">
-        {ctaLabel} <ArrowRight size={14} />
-      </PillButton>
+      </Link>
+      <div style={{ display: "flex", alignItems: "center", gap: isDesktop ? 16 : 10 }}>
+        {showAuthLinks ? (
+          <>
+            <Link
+              href="/sign-in"
+              style={{
+                color: BLACK,
+                fontSize: 14,
+                fontWeight: 600,
+                textDecoration: "none",
+                whiteSpace: "nowrap",
+              }}
+            >
+              Sign in
+            </Link>
+            {isDesktop ? (
+              <PillButton href="/sign-up" variant="secondary" size="sm">
+                Sign up
+              </PillButton>
+            ) : null}
+          </>
+        ) : null}
+        <PillButton href={ctaHref} variant="dark" size="sm">
+          {ctaLabel} <ArrowRight size={14} />
+        </PillButton>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
Adds Sign in / Sign up navigation to the landing header (`TopNav`) and footer, reaching the existing `/sign-in` and `/sign-up` Google-OAuth pages, with styling consistent with the site's existing pills and links. Internal links across the landing components now use `next/link` for client-side navigation, with `PillButton` choosing `<Link>` vs `<a>` based on the href so external links (social, GitHub) stay plain anchors. The Next.js frontend guide documents this navigation convention.