### PR TITLE
fix(site): re-mint expiring cloud media URLs on foreground and on read failure

### DIFF
--- a/site/src/cut/components/Editor.tsx
+++ b/site/src/cut/components/Editor.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { apiFetch, setCutMode } from "@/cut/lib/backend";
 import { renderPreviewProxy } from "@/cut/lib/exportClient";
 import { fileZoneAt, hasRefDrag } from "@/cut/lib/assetRef";
-import { enrichAsset, importFileToProject } from "@/cut/lib/media";
+import { enrichAsset, importFileToProject, remintExpiringMediaUrls } from "@/cut/lib/media";
 // Side-effect import: registers the brief-to-video resume subscription, so a
 // persisted run resumes on project load even when the AI panel never mounts.
 import "@/cut/lib/genScene";
@@ -74,6 +74,21 @@ export function Editor({
       alive = false;
     };
   }, [projectId]);
+
+  // Cloud media rides signed URLs with a 24h life. When the tab returns to the
+  // foreground inside the mint's last hour, re-mint before playback hits a
+  // dead URL; a read that still fails re-mints on its own (lib/media.ts).
+  useEffect(() => {
+    const check = () => {
+      if (document.visibilityState === "visible") remintExpiringMediaUrls();
+    };
+    window.addEventListener("focus", check);
+    document.addEventListener("visibilitychange", check);
+    return () => {
+      window.removeEventListener("focus", check);
+      document.removeEventListener("visibilitychange", check);
+    };
+  }, []);
 
   // A cloud save hit a newer stored version (another session's edits won).
   // Take the newer doc through the ordinary load path — the GET returns it and

--- a/site/src/cut/components/GeneratePanel.tsx
+++ b/site/src/cut/components/GeneratePanel.tsx
@@ -17,6 +17,7 @@ import { useInView } from "@/cut/hooks/useInView";
 import { genPulseOverlay, useGenPulse } from "@/cut/lib/genNotify";
 import { signInUrl, useGenerate, useSignedIn, type GenerateJob } from "@/cut/lib/generate";
 import { useLightbox } from "@/cut/lib/lightbox";
+import { remintAfterMediaFailure } from "@/cut/lib/media";
 import { refsFromDroppedFiles } from "@/cut/lib/refMedia";
 import { characterPrompt, stockTitle } from "@/cut/lib/stock";
 import { useEditor } from "@/cut/lib/store";
@@ -342,6 +343,7 @@ function JobRow({ job, handle }: { job: GenerateJob; handle?: string }) {
           playsInline
           preload="metadata"
           src={seen ? `${asset.url}#t=0.1` : undefined}
+          onError={() => void remintAfterMediaFailure(asset.url)}
           className="aspect-[16/10] w-full bg-black object-cover"
         />
       </button>

--- a/site/src/cut/components/ImageGenPanel.tsx
+++ b/site/src/cut/components/ImageGenPanel.tsx
@@ -17,6 +17,7 @@ import {
   type ImageResolution,
 } from "@/cut/lib/imageGen";
 import { useLightbox } from "@/cut/lib/lightbox";
+import { remintAfterMediaFailure } from "@/cut/lib/media";
 import { refsFromDroppedFiles } from "@/cut/lib/refMedia";
 import { useEditor } from "@/cut/lib/store";
 import type { MediaAsset } from "@/cut/lib/types";
@@ -249,6 +250,7 @@ function GeneratedTile({
           src={asset.url}
           alt={asset.name}
           loading="lazy"
+          onError={() => void remintAfterMediaFailure(asset.url)}
           className="aspect-[16/10] w-full bg-black object-cover transition-transform group-hover:scale-[1.04]"
         />
       </button>

--- a/site/src/cut/components/SidePanel.tsx
+++ b/site/src/cut/components/SidePanel.tsx
@@ -59,7 +59,7 @@ import {
   type LibraryAsset,
   type LibraryFolder,
 } from "@/cut/lib/library";
-import { revealMedia } from "@/cut/lib/media";
+import { remintAfterMediaFailure, revealMedia } from "@/cut/lib/media";
 import { mediaUrl, TRANSITION_MAX, type LibraryTemplate } from "@/cut/lib/types";
 import { genPulseOverlay, isGenTab, useGenNotify, useGenPulse, useWatchGenTab } from "@/cut/lib/genNotify";
 import { CAPTION_LIMIT, normalizeTags } from "@/cut/lib/publish";
@@ -725,11 +725,18 @@ function AssetCard({ asset, projectId }: { asset: MediaAsset; projectId: string 
             muted
             loop
             playsInline
+            onError={() => void remintAfterMediaFailure(asset.url)}
             className="size-full object-cover"
           />
         ) : asset.type === "image" ? (
           // eslint-disable-next-line @next/next/no-img-element -- engine/static file, not Next-optimizable
-          <img src={asset.url} alt={asset.name} loading="lazy" className="size-full object-cover" />
+          <img
+            src={asset.url}
+            alt={asset.name}
+            loading="lazy"
+            onError={() => void remintAfterMediaFailure(asset.url)}
+            className="size-full object-cover"
+          />
         ) : (
           <AudioCardFace
             url={asset.url}

--- a/site/src/cut/hooks/usePlayback.ts
+++ b/site/src/cut/hooks/usePlayback.ts
@@ -6,6 +6,7 @@ import { isFullRect, overlayAnimStyle, projectFadeSeconds, rectOf, TRANSITION_ZO
 import type { AudioClip, ClipAnim, ClipSpan, FrameRect, MediaAsset, TransitionStyle, VideoClip } from "@/cut/lib/types";
 import { gradeTint, gradeToCssFilter, isNeutralGrade } from "@/cut/lib/colorGrade";
 import { grainTile, lookCssFilter, lookPost } from "@/cut/lib/looks";
+import { remintAfterMediaFailure } from "@/cut/lib/media";
 import { registerSourceSampler } from "@/cut/lib/previewCanvas";
 
 /** The alpha/zoom/gain ramps a transition or clip animation puts on one
@@ -205,9 +206,12 @@ const pauseEl = (el: MediaEl) => {
 /** Build the decoder element for a clip's asset: an <img> for a still, a
  * hidden <video> for footage. */
 function makeMediaEl(asset: MediaAsset): MediaEl {
+  // An expired cloud URL re-mints on failure; the store swap changes asset.url
+  // and `elFor`'s src mismatch rebuilds this element against the fresh URL.
   if (asset.type === "image") {
     const img = document.createElement("img");
     img.crossOrigin = "anonymous";
+    img.onerror = () => void remintAfterMediaFailure(asset.url);
     img.src = asset.url;
     return img;
   }
@@ -215,6 +219,7 @@ function makeMediaEl(asset: MediaAsset): MediaEl {
   v.playsInline = true;
   v.preload = "auto";
   v.crossOrigin = "anonymous";
+  v.onerror = () => void remintAfterMediaFailure(asset.url);
   v.src = asset.url;
   return v;
 }
@@ -1134,6 +1139,8 @@ class Engine {
       if (!el) {
         el = new Audio(asset.url);
         el.preload = "auto";
+        // An expired cloud URL re-mints; the src mismatch above rebuilds it.
+        el.onerror = () => void remintAfterMediaFailure(asset.url);
         this.audioEls.set(a.id, el);
       }
       // Detached audio can carry its video clip's rate; footprint is (out-in)/speed.

--- a/site/src/cut/lib/backend/cloud.ts
+++ b/site/src/cut/lib/backend/cloud.ts
@@ -53,6 +53,21 @@ async function cloudFetch(path: string, init?: RequestInit): Promise<Response> {
   return res;
 }
 
+// Signed GETs live 24h (server/cloud/r2.ts GET_EXPIRY_SECONDS); within the
+// last hour of that life a mint counts as expiring.
+const SIGNED_GET_TTL_MS = 24 * 60 * 60 * 1000;
+const EXPIRING_MARGIN_MS = 60 * 60 * 1000;
+
+let lastMint: { projectId: string; at: number } | null = null;
+
+/** True when `projectId`'s signed media URLs expire within the hour. */
+export function signedUrlsExpireSoon(projectId: string): boolean {
+  return (
+    lastMint?.projectId === projectId &&
+    Date.now() - lastMint.at > SIGNED_GET_TTL_MS - EXPIRING_MARGIN_MS
+  );
+}
+
 /** Batch-mint signed R2 GET URLs for a cloud project's media files. Returns
  * fileName -> url; anything the mint misses keeps the /media route, whose 302
  * serves the same bytes. */
@@ -71,6 +86,7 @@ export async function fetchSignedMediaUrls(
     if (!res.ok) return out;
     const body = (await res.json()) as { urls?: { fileName: string; url: string }[] };
     for (const u of body.urls ?? []) out.set(u.fileName, u.url);
+    lastMint = { projectId, at: Date.now() };
   } catch {
     // Signed URLs are an optimization; the route fallback still streams.
   }

--- a/site/src/cut/lib/media.ts
+++ b/site/src/cut/lib/media.ts
@@ -769,16 +769,19 @@ export function remintProjectMediaUrls(): Promise<boolean> {
 }
 
 /** Foreground check: re-mint when the current project's signed URLs expire
- * within the hour. */
+ * within the hour. Cloud projects only. */
 export function remintExpiringMediaUrls() {
+  if (getBackend().kind !== "cloud") return;
   const { projectId } = useEditor.getState();
   if (projectId && signedUrlsExpireSoon(projectId)) void remintProjectMediaUrls();
 }
 
-/** Failure path: `failedUrl` just failed to load. If it is a project asset's
- * URL, re-mint and resolve with that asset's fresh URL — null when nothing
- * changed (not a project asset, cooldown, or the mint returned the same URL). */
+/** Failure path: `failedUrl` just failed to load. If it is a cloud project
+ * asset's URL, re-mint and resolve with that asset's fresh URL — null when
+ * nothing changed (local project, not a project asset, cooldown, or the mint
+ * returned the same URL). */
 export async function remintAfterMediaFailure(failedUrl: string): Promise<string | null> {
+  if (getBackend().kind !== "cloud") return null;
   const asset = useEditor.getState().assets.find((a) => a.url === failedUrl);
   if (!asset) return null;
   if (!(await remintProjectMediaUrls())) return null;

--- a/site/src/cut/lib/media.ts
+++ b/site/src/cut/lib/media.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { apiFetch, apiJson, getBackend, type CutBackend } from "./backend";
-import { quotaErrorMessage } from "./backend/cloud";
+import { fetchSignedMediaUrls, quotaErrorMessage, signedUrlsExpireSoon } from "./backend/cloud";
 import { encodeWav } from "./cloudTranscribe";
 import { useEditor } from "./store";
 import type { AssetType, AudioClip, MediaAsset, ProjectSummary, StoredAsset, VideoClip } from "./types";
@@ -624,13 +624,17 @@ const cellDims = (w: number, h: number): [number, number] =>
 /** Cloud twin of the engine's watch route for a still image: one downscaled
  * cell, no time axis. */
 export async function makeStillSheetClientSide(sourceUrl: string): Promise<WatchSheets> {
-  const img = new Image();
-  img.crossOrigin = "anonymous";
-  await new Promise<void>((resolve, reject) => {
-    img.onload = () => resolve();
-    img.onerror = () => reject(new Error("Could not read the image."));
-    img.src = sourceUrl;
-  });
+  const img = await withFreshUrl(
+    sourceUrl,
+    (url) =>
+      new Promise<HTMLImageElement>((resolve, reject) => {
+        const el = new Image();
+        el.crossOrigin = "anonymous";
+        el.onload = () => resolve(el);
+        el.onerror = () => reject(new Error("Could not read the image."));
+        el.src = url;
+      })
+  );
   if (img.naturalWidth === 0 || img.naturalHeight === 0)
     throw new Error("Could not read the image.");
   const [w, h] = cellDims(img.naturalWidth, img.naturalHeight);
@@ -659,7 +663,7 @@ export async function makeContactSheetsClientSide(
   sourceUrl: string,
   opts: { from: number; to?: number; interval?: number }
 ): Promise<WatchSheets> {
-  const v = await loadVideoMeta(sourceUrl);
+  const v = await withFreshUrl(sourceUrl, loadVideoMeta);
   try {
     if (v.videoWidth === 0) throw new Error("Could not sample the video.");
     const from = Math.max(0, opts.from);
@@ -720,6 +724,89 @@ export async function makeContactSheetsClientSide(
   }
 }
 
+// --- Cloud signed-URL re-mint ---
+// Cloud media URLs are signed R2 GETs with a 24h life, batch-minted at project
+// load, so a tab left open outlives them. Two paths share one re-mint that
+// swaps fresh URLs into the store's assets: the editor re-mints proactively
+// when the tab returns to the foreground inside the mint's last hour, and any
+// media read that fails re-mints and retries once. Every consumer derives from
+// asset.url — the playback engine rebuilds elements on a src mismatch, edge
+// frames and panel previews re-render — so the store swap heals them all.
+
+const REMINT_COOLDOWN_MS = 15_000; // collapse an error storm into one mint
+
+let remintInFlight: Promise<boolean> | null = null;
+let remintDoneAt = 0;
+
+/** Re-mint the current cloud project's signed media URLs into the store.
+ * Deduped and cooled down; resolves true when any asset URL changed. */
+export function remintProjectMediaUrls(): Promise<boolean> {
+  if (remintInFlight) return remintInFlight;
+  if (getBackend().kind !== "cloud") return Promise.resolve(false);
+  if (Date.now() - remintDoneAt < REMINT_COOLDOWN_MS) return Promise.resolve(false);
+  const { projectId, assets } = useEditor.getState();
+  if (!projectId || assets.length === 0) return Promise.resolve(false);
+  remintInFlight = (async () => {
+    try {
+      const signed = await fetchSignedMediaUrls(projectId, assets.map((a) => a.fileName));
+      const st = useEditor.getState();
+      if (st.projectId !== projectId) return false; // switched projects mid-mint
+      let changed = false;
+      for (const a of st.assets) {
+        const url = signed.get(a.fileName);
+        if (url && url !== a.url) {
+          st.updateAsset(a.id, { url });
+          changed = true;
+        }
+      }
+      return changed;
+    } finally {
+      remintDoneAt = Date.now();
+      remintInFlight = null;
+    }
+  })();
+  return remintInFlight;
+}
+
+/** Foreground check: re-mint when the current project's signed URLs expire
+ * within the hour. */
+export function remintExpiringMediaUrls() {
+  const { projectId } = useEditor.getState();
+  if (projectId && signedUrlsExpireSoon(projectId)) void remintProjectMediaUrls();
+}
+
+/** Failure path: `failedUrl` just failed to load. If it is a project asset's
+ * URL, re-mint and resolve with that asset's fresh URL — null when nothing
+ * changed (not a project asset, cooldown, or the mint returned the same URL). */
+export async function remintAfterMediaFailure(failedUrl: string): Promise<string | null> {
+  const asset = useEditor.getState().assets.find((a) => a.url === failedUrl);
+  if (!asset) return null;
+  if (!(await remintProjectMediaUrls())) return null;
+  const fresh = useEditor.getState().assets.find((a) => a.id === asset.id)?.url;
+  return fresh && fresh !== failedUrl ? fresh : null;
+}
+
+/** Run a media read, re-minting and retrying once when it fails on an expired
+ * asset URL. */
+async function withFreshUrl<T>(url: string, run: (url: string) => Promise<T>): Promise<T> {
+  try {
+    return await run(url);
+  } catch (e) {
+    const fresh = await remintAfterMediaFailure(url);
+    if (!fresh) throw e;
+    return run(fresh);
+  }
+}
+
+/** makePeaks with the failure re-mint: a decode failure surfaces as empty
+ * peaks, not a throw, so emptiness is the retry trigger. */
+async function makePeaksFresh(url: string): Promise<number[]> {
+  const peaks = await makePeaks(url);
+  if (peaks.length) return peaks;
+  const fresh = await remintAfterMediaFailure(url);
+  return fresh ? makePeaks(fresh) : peaks;
+}
+
 /** Generate filmstrip thumbnails / waveform peaks and merge them into the
  * store. Safe to call repeatedly; skips assets that are already enriched. */
 export async function enrichAsset(asset: MediaAsset) {
@@ -735,12 +822,12 @@ export async function enrichAsset(asset: MediaAsset) {
       if (cached) {
         useEditor.getState().updateAsset(asset.id, { thumbs: cached.thumbs, thumbStep: cached.thumbStep });
       } else {
-        const { thumbs, thumbStep } = await makeThumbs(asset.url, asset.duration);
+        const { thumbs, thumbStep } = await withFreshUrl(asset.url, (u) => makeThumbs(u, asset.duration));
         useEditor.getState().updateAsset(asset.id, { thumbs, thumbStep });
         writeCachedStrip(key, { thumbs, thumbStep, duration: asset.duration, at: Date.now() });
       }
     } else if (asset.type === "audio" && !asset.peaks?.length) {
-      const peaks = await makePeaks(asset.url);
+      const peaks = await makePeaksFresh(asset.url);
       useEditor.getState().updateAsset(asset.id, { peaks });
     }
   } catch {
@@ -753,7 +840,7 @@ export async function enrichAsset(asset: MediaAsset) {
 export async function ensurePeaks(asset: MediaAsset) {
   try {
     if (!asset.peaks?.length) {
-      const peaks = await makePeaks(asset.url);
+      const peaks = await makePeaksFresh(asset.url);
       useEditor.getState().updateAsset(asset.id, { peaks });
     }
   } catch {
@@ -1005,6 +1092,17 @@ async function pumpEdgeFrames() {
           }
         } catch {
           src = null;
+          // Release the dead pooled element and re-mint; the store URL swap
+          // re-renders clip edges, which re-request against the fresh URL.
+          const dead = edgePool.get(req.url);
+          edgePool.delete(req.url);
+          dead
+            ?.then((v) => {
+              v.removeAttribute("src");
+              v.load();
+            })
+            .catch(() => {});
+          void remintAfterMediaFailure(req.url);
         }
       }
       req.resolvers.forEach((r) => r(src));

--- a/site/src/cut/lib/previewAudio.ts
+++ b/site/src/cut/lib/previewAudio.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { create } from "zustand";
+import { remintAfterMediaFailure } from "./media";
 
 // One shared preview player for every "play this audio" affordance — Audio
 // panel rows and chat audio cards. Starting a preview stops the last one, and
@@ -33,6 +34,8 @@ export const usePreviewAudio = create<PreviewAudioState>((set, get) => ({
     // Only the load that still owns the state may clear it — a superseded load's
     // late error/rejection must not knock out the preview playing now.
     audio.onerror = () => {
+      // An expired cloud asset URL re-mints; the next press plays the fresh one.
+      void remintAfterMediaFailure(url);
       if (get().url === url) set({ url: null });
     };
     set({ url });


### PR DESCRIPTION
Cloud signed R2 GET URLs live 24h but were minted once per project load,
so a tab left open for days lost playback, edge frames, and late
enrichment. Two paths now share one deduped re-mint that swaps fresh
URLs into the store's assets: the editor re-mints when the tab returns
to the foreground inside the mint's last hour, and any media read that
fails re-mints and retries once (filmstrips, waveform peaks, contact
sheets, edge frames, playback elements, panel previews).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DViLfSbRW3918VRTYovgQ5