### PR TITLE
feat(site): store cloud AI chat threads in Postgres

### DIFF
--- a/docs/guides/cut/ai-assistant.md
+++ b/docs/guides/cut/ai-assistant.md
@@ -80,7 +80,7 @@ Because a scene renders many paid shots, the tool plans and then stops. `generat
 
 ## Context across turns
 
-Threads persist per project in the browser's local storage — the newest 30, titled by their first message. What a returning thread remembers depends on the provider:
+Threads persist per project — the newest 30, titled by their first message. The browser's local storage is the synchronous mirror every reader uses; in cloud mode the server keeps the account copy (`CutChatThread`, one row per thread), pulled into the mirror on project open and pushed back per thread as the conversation grows, so chats follow the account across browsers. Local mode has no server copy. What a returning thread remembers depends on the provider:
 
 - **Claude and Codex hold their own history.** Each turn sends only the newest message plus the fresh snapshot; prior turns live in the provider's native session, whose id is saved on the thread and resumed. The engine never replays conversation history itself.
 - **Gemini is stateless.** The page replays the whole thread every turn — text only. Old turns are stripped to their words; tool traffic, old snapshots, and old attachment payloads stay out, and the fresh snapshot rides only the newest message.

--- a/site/prisma/Cut.prisma
+++ b/site/prisma/Cut.prisma
@@ -48,6 +48,25 @@ model CutMediaObject {
   @@index([projectId, kind])
 }
 
+// One saved AI chat thread — the chat panel's per-project history, stored
+// server-side so cloud chats follow the account across browsers. The id is the
+// client-minted thread uuid. `messages` holds the slimmed UIMessage list the
+// panel persists (bulky frame payloads already stripped); `sessions` the
+// provider-native session ids. `updatedAt` mirrors the client's thread clock
+// so ordering matches the panel's Threads list.
+model CutChatThread {
+  id        String   @id
+  userId    String
+  projectId String
+  title     String
+  messages  Json
+  sessions  Json
+  updatedAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([userId, projectId, updatedAt])
+}
+
 model CutLibraryAsset {
   id            String   @id @default(cuid())
   userId        String

--- a/site/src/cut/components/AiPanel.tsx
+++ b/site/src/cut/components/AiPanel.tsx
@@ -41,12 +41,18 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { engineReady } from "@/cut/lib/api";
-import { apiFetch, apiUrl } from "@/cut/lib/backend";
+import { apiFetch, apiUrl, cutMode } from "@/cut/lib/backend";
 import { useCutCaps } from "@/cut/lib/backend/hooks";
 import { buildAiContext } from "@/cut/lib/aiContext";
 import { runAiTool } from "@/cut/lib/aiTools";
 import { setAssetDragData } from "@/cut/lib/assetDrag";
-import { activeChatKey, threadsKey } from "@/cut/lib/chatThreads";
+import {
+  activeChatKey,
+  pushThread,
+  pushThreadDelete,
+  syncProjectThreads,
+  threadsKey,
+} from "@/cut/lib/chatThreads";
 import {
   beginChatTurn,
   deleteChatAssets,
@@ -98,7 +104,8 @@ interface ModelsInfo {
   providers: Record<string, { available: boolean; note: string; installed?: boolean }>;
 }
 
-/** A saved chat thread, persisted per project in localStorage. */
+/** A saved chat thread, persisted per project in localStorage (the mirror the
+ * cloud copy syncs through — see lib/chatThreads.ts). */
 interface ChatThread {
   id: string;
   title: string;
@@ -125,10 +132,10 @@ function readThreads(projectId: string): ChatThread[] {
  * watch_video result carries ~1MB of contact sheets and localStorage holds a
  * few MB per origin. The live thread keeps its images; replayed turns only
  * ever reuse text parts, so nothing downstream misses them. */
-function slimForStorage(list: ChatThread[]): ChatThread[] {
+function slimThread(t: ChatThread): ChatThread {
   const bulky = (v: unknown) =>
     typeof v === "string" && v.startsWith("data:image/");
-  return list.map((t) => ({
+  return {
     ...t,
     messages: t.messages.map((m) => ({
       ...m,
@@ -152,7 +159,7 @@ function slimForStorage(list: ChatThread[]): ChatThread[] {
         } as typeof p;
       }),
     })),
-  }));
+  };
 }
 
 function writeThreads(projectId: string, list: ChatThread[]) {
@@ -166,15 +173,19 @@ function writeThreads(projectId: string, list: ChatThread[]) {
       .filter((t) => threadOwnsAssets(t.id) || threadHasLiveRun(t.id)),
   ];
   // A pruned thread is gone the way a deleted one is — anything it still
-  // owned (by construction nothing live) dies with it.
+  // owned (by construction nothing live) dies with it, locally and on the
+  // account copy.
   const keptIds = new Set(kept.map((t) => t.id));
   for (const t of list) {
-    if (!keptIds.has(t.id)) useGenScene.getState().killThread(t.id);
+    if (!keptIds.has(t.id)) {
+      useGenScene.getState().killThread(t.id);
+      pushThreadDelete(projectId, t.id);
+    }
   }
   try {
     localStorage.setItem(
       threadsKey(projectId),
-      JSON.stringify(slimForStorage(kept)),
+      JSON.stringify(kept.map(slimThread)),
     );
   } catch {
     // Storage full/blocked — history just won't persist.
@@ -242,6 +253,21 @@ export function AiPanel({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [threads, setThreads] = useState<ChatThread[]>([]);
 
+  // Cloud threads live on the account: pull them into the local mirror before
+  // the chat mounts, so a conversation started in another browser resumes
+  // here. Local mode has nothing to pull and renders immediately.
+  const [threadsReady, setThreadsReady] = useState(() => cutMode() !== "cloud");
+  useEffect(() => {
+    if (threadsReady) return;
+    let alive = true;
+    void syncProjectThreads(projectId).finally(
+      () => alive && setThreadsReady(true),
+    );
+    return () => {
+      alive = false;
+    };
+  }, [threadsReady, projectId]);
+
   useEffect(() => {
     // The models probe asks the engine which CLIs are installed; without the
     // localCliChat cap there is no engine to ask (mergedInfo synthesizes the
@@ -277,6 +303,7 @@ export function AiPanel({
       projectId,
       readThreads(projectId).filter((t) => t.id !== id),
     );
+    pushThreadDelete(projectId, id);
     setThreads((p) => p.filter((t) => t.id !== id));
     // The thread's chat-only assets go with it; anything placed or filed
     // into Media/Library stays.
@@ -405,14 +432,16 @@ export function AiPanel({
         </>
       )}
 
-      <ChatSession
-        key={activeChat}
-        projectId={projectId}
-        threadId={activeChat}
-        info={mergedInfo}
-        model={model}
-        onModelChange={selectModel}
-      />
+      {threadsReady && (
+        <ChatSession
+          key={activeChat}
+          projectId={projectId}
+          threadId={activeChat}
+          info={mergedInfo}
+          model={model}
+          onModelChange={selectModel}
+        />
+      )}
     </aside>
   );
 }
@@ -645,16 +674,16 @@ function ChatSession({
         .trim()
         .slice(0, 80) || "New chat";
     const rest = readThreads(projectId).filter((t) => t.id !== threadId);
-    writeThreads(projectId, [
-      {
-        id: threadId,
-        title,
-        updatedAt: Date.now(),
-        messages,
-        sessions: { ...providerSessions.current },
-      },
-      ...rest,
-    ]);
+    const thread: ChatThread = {
+      id: threadId,
+      title,
+      updatedAt: Date.now(),
+      messages,
+      sessions: { ...providerSessions.current },
+    };
+    writeThreads(projectId, [thread, ...rest]);
+    // The account copy gets the same slimmed thread, debounced per thread.
+    pushThread(projectId, slimThread(thread));
   }, [messages, threadId, projectId]);
 
   // Stay glued to the newest message while the user sits at the bottom;

--- a/site/src/cut/components/Editor.tsx
+++ b/site/src/cut/components/Editor.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Clapperboard, Loader2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { apiFetch, setCutMode } from "@/cut/lib/backend";
+import { syncProjectThreads } from "@/cut/lib/chatThreads";
 import { renderPreviewProxy } from "@/cut/lib/exportClient";
 import { fileZoneAt, hasRefDrag } from "@/cut/lib/assetRef";
 import { enrichAsset, importFileToProject } from "@/cut/lib/media";
@@ -60,6 +61,9 @@ export function Editor({
     void resolveProjectMode(projectId).then((mode) => {
       if (!alive) return;
       setCutMode(mode);
+      // Pull the account's chat threads into the local mirror alongside the
+      // doc, so the AI panel and the render-resume guard read fresh history.
+      void syncProjectThreads(projectId);
       void useEditor
         .getState()
         .loadProject(projectId)

--- a/site/src/cut/lib/chatThreads.ts
+++ b/site/src/cut/lib/chatThreads.ts
@@ -1,8 +1,10 @@
-// Chat history is per project, stored in localStorage. The keys and a couple of
-// raw readers live in this leaf module (importing nothing app-specific) so both
-// the AI panel — which owns the history — and the generate store — which must
-// refuse to resume a render whose thread the user deleted — can reach it without
-// importing each other.
+// Chat history is per project. localStorage is the synchronous mirror every
+// reader uses; in cloud mode the server keeps the account copy, and this
+// module owns the sync between the two (pull on project open, debounced push
+// per thread). It lives below the AI panel — which owns the history — and the
+// generate store — which must refuse to resume a render whose thread the user
+// deleted — so the two can reach it without importing each other.
+import { apiFetch, cutMode } from "./backend";
 
 // The keys derive from the route's project id, never the editor store's
 // projectId (that still points at the previously open project until loadProject
@@ -28,7 +30,8 @@ export function readThreadIds(projectId: string): Set<string> {
 }
 
 /** Drop a project's chat history and active-thread pointer — called when the
- * project itself is deleted, so no stale thread or its renders survive it. */
+ * project itself is deleted, so no stale thread or its renders survive it.
+ * Server rows go with the project (the cloud delete cascades them). */
 export function clearProjectThreads(projectId: string): void {
   try {
     localStorage.removeItem(threadsKey(projectId));
@@ -36,4 +39,106 @@ export function clearProjectThreads(projectId: string): void {
   } catch {
     // Storage blocked — nothing to clear.
   }
+}
+
+// ---- Cloud sync -------------------------------------------------------------
+// The panel stores threads slimmed (frame payloads stripped), so the pushed
+// copy is exactly the mirrored one. Every call below is a no-op in local mode.
+
+/** The wire shape of one saved thread; the panel's ChatThread narrows it. */
+export interface StoredChatThread {
+  id: string;
+  title: string;
+  updatedAt: number;
+  messages: unknown[];
+  sessions: Record<string, string>;
+}
+
+const chatPath = (projectId: string, chatId?: string) =>
+  `/api/cut/projects/${encodeURIComponent(projectId)}/chats` +
+  (chatId ? `/${encodeURIComponent(chatId)}` : "");
+
+// One debounced PUT per thread: the panel saves on every streamed chunk, and
+// the trailing edge (plus the next turn's saves) keeps the server copy close
+// without a request per token.
+const PUSH_DEBOUNCE_MS = 1000;
+const pushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+// Projects with a push still queued or in flight; a pull that landed mid-write
+// must not clobber the newer local mirror with the server's older copy.
+const dirtyProjects = new Map<string, number>();
+
+const markDirty = (projectId: string) =>
+  dirtyProjects.set(projectId, (dirtyProjects.get(projectId) ?? 0) + 1);
+const clearDirty = (projectId: string) => {
+  const n = (dirtyProjects.get(projectId) ?? 1) - 1;
+  if (n <= 0) dirtyProjects.delete(projectId);
+  else dirtyProjects.set(projectId, n);
+};
+
+/** Queue the server copy of one thread (cloud mode only). */
+export function pushThread(projectId: string, thread: StoredChatThread): void {
+  if (cutMode() !== "cloud") return;
+  const key = `${projectId}/${thread.id}`;
+  const pending = pushTimers.get(key);
+  if (pending) clearTimeout(pending);
+  else markDirty(projectId);
+  pushTimers.set(
+    key,
+    setTimeout(() => {
+      pushTimers.delete(key);
+      void apiFetch(chatPath(projectId, thread.id), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(thread),
+      })
+        .catch(() => {
+          // Offline — the mirror still has it; the next turn's push retries.
+        })
+        .finally(() => clearDirty(projectId));
+    }, PUSH_DEBOUNCE_MS),
+  );
+}
+
+/** Delete a thread's server copy (cloud mode only). */
+export function pushThreadDelete(projectId: string, threadId: string): void {
+  if (cutMode() !== "cloud") return;
+  const key = `${projectId}/${threadId}`;
+  const pending = pushTimers.get(key);
+  if (pending) {
+    clearTimeout(pending);
+    pushTimers.delete(key);
+    clearDirty(projectId);
+  }
+  void apiFetch(chatPath(projectId, threadId), { method: "DELETE" }).catch(() => {
+    // Offline — the project-scoped rows are also cleaned when the project goes.
+  });
+}
+
+const syncs = new Map<string, Promise<void>>();
+
+/** Pull the account's threads into the local mirror (cloud mode only).
+ * Callers await it before the first mirror read so a chat started on another
+ * browser resumes here; concurrent calls share one fetch. Failures resolve —
+ * the mirror keeps serving whatever it has. */
+export function syncProjectThreads(projectId: string): Promise<void> {
+  if (cutMode() !== "cloud") return Promise.resolve();
+  let p = syncs.get(projectId);
+  if (p) return p;
+  p = (async () => {
+    try {
+      const res = await apiFetch(chatPath(projectId));
+      if (!res.ok) return;
+      const list = (await res.json()) as unknown;
+      if (!Array.isArray(list)) return;
+      // A local write raced the pull; its push is newer than what we fetched.
+      if (dirtyProjects.has(projectId)) return;
+      localStorage.setItem(threadsKey(projectId), JSON.stringify(list));
+    } catch {
+      // Offline or blocked — the mirror keeps serving.
+    } finally {
+      syncs.delete(projectId);
+    }
+  })();
+  syncs.set(projectId, p);
+  return p;
 }

--- a/site/src/cut/server/cloud/chats.ts
+++ b/site/src/cut/server/cloud/chats.ts
@@ -1,0 +1,98 @@
+// Cloud storage for the chat panel's per-project AI threads. The client owns
+// the thread shape (id, title, updatedAt, messages, sessions) and mirrors it in
+// localStorage for synchronous reads; these routes are the account copy that
+// follows the user across browsers. Last write wins per thread — the panel
+// pushes the whole thread after each turn.
+import type { Prisma } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import { getProject } from "./projects";
+import { caught, err } from "./util";
+
+// A thread is bounded client-side by localStorage (frame payloads stripped
+// before save); this bound only rejects a client gone wrong.
+const MAX_THREAD_BYTES = 4_000_000;
+
+// Client thread ids come from crypto.randomUUID().
+const THREAD_ID = /^[0-9a-fA-F-]{1,64}$/;
+
+type ThreadBody = {
+  id: string;
+  title: string;
+  updatedAt: number;
+  messages: unknown[];
+  sessions: Record<string, string>;
+};
+
+function parseThread(raw: unknown): ThreadBody | null {
+  if (!raw || typeof raw !== "object") return null;
+  const t = raw as Record<string, unknown>;
+  if (typeof t.id !== "string" || !THREAD_ID.test(t.id)) return null;
+  if (typeof t.title !== "string" || typeof t.updatedAt !== "number") return null;
+  if (!Array.isArray(t.messages)) return null;
+  const sessions = t.sessions;
+  if (!sessions || typeof sessions !== "object" || Array.isArray(sessions)) return null;
+  if (Object.values(sessions).some((v) => typeof v !== "string")) return null;
+  return t as ThreadBody;
+}
+
+const toClient = (row: {
+  id: string;
+  title: string;
+  updatedAt: Date;
+  messages: unknown;
+  sessions: unknown;
+}) => ({
+  id: row.id,
+  title: row.title,
+  updatedAt: row.updatedAt.getTime(),
+  messages: row.messages,
+  sessions: row.sessions,
+});
+
+export const chatsCloud = {
+  /** Every saved thread in a project, newest first — the panel's Threads list. */
+  async list(userId: string, projectId: string) {
+    if (!(await getProject(userId, projectId))) return err("Project not found.", 404);
+    const rows = await prisma.cutChatThread.findMany({
+      where: { userId, projectId },
+      orderBy: { updatedAt: "desc" },
+    });
+    return Response.json(rows.map(toClient));
+  },
+
+  /** Upsert one thread. The row id is the client's uuid, so ownership is
+   * checked against any existing row before writing — a colliding id owned by
+   * another user or project reads as not-found rather than being clobbered. */
+  async put(userId: string, projectId: string, chatId: string, req: Request) {
+    try {
+      const text = await req.text();
+      if (text.length > MAX_THREAD_BYTES) return err("Thread too large.", 413);
+      const body = parseThread(JSON.parse(text));
+      if (!body || body.id !== chatId) return err("Invalid thread.", 400);
+      if (!(await getProject(userId, projectId))) return err("Project not found.", 404);
+      const existing = await prisma.cutChatThread.findUnique({ where: { id: chatId } });
+      if (existing && (existing.userId !== userId || existing.projectId !== projectId)) {
+        return err("Thread not found.", 404);
+      }
+      const data = {
+        title: body.title,
+        updatedAt: new Date(body.updatedAt),
+        messages: body.messages as Prisma.InputJsonValue,
+        sessions: body.sessions as Prisma.InputJsonValue,
+      };
+      await prisma.cutChatThread.upsert({
+        where: { id: chatId },
+        update: data,
+        create: { id: chatId, userId, projectId, ...data },
+      });
+      return Response.json({ ok: true });
+    } catch (e) {
+      return caught(e, "Could not save thread.");
+    }
+  },
+
+  async remove(userId: string, projectId: string, chatId: string) {
+    await prisma.cutChatThread.deleteMany({ where: { id: chatId, userId, projectId } });
+    return Response.json({ ok: true });
+  },
+};

--- a/site/src/cut/server/cloud/projects.ts
+++ b/site/src/cut/server/cloud/projects.ts
@@ -218,6 +218,7 @@ export const projectsCloud = {
       });
       await prisma.$transaction(async (tx) => {
         await tx.cutMediaObject.deleteMany({ where: { userId, projectId: id } });
+        await tx.cutChatThread.deleteMany({ where: { userId, projectId: id } });
         await tx.cutProject.delete({ where: { id } });
         await addUsage(tx, userId, -freed);
       });

--- a/site/src/cut/server/cloud/routes.ts
+++ b/site/src/cut/server/cloud/routes.ts
@@ -7,6 +7,7 @@
 import { type DonkeyAuthenticatedRequest, isDonkeySuperUser } from "@/lib/donkey-api-auth";
 import { matchRouteTable, type RouteEntry } from "../http/match";
 import { captionsCloud } from "./captions";
+import { chatsCloud } from "./chats";
 import { runGc } from "./gc";
 import { jobsCloud } from "./jobs";
 import { libraryCloud } from "./library";
@@ -48,6 +49,12 @@ const CUT_CLOUD_ROUTES: CloudRoute[] = [
   { method: "POST", path: "/api/cut-cloud/projects/:id/media/complete", handler: (r, u) => mediaCloud.complete(u, r) },
   { method: "POST", path: "/api/cut-cloud/projects/:id/import-url", handler: (r, u, p) => jobsCloud.importUrl(u, p.id, r) },
   { method: "POST", path: "/api/cut-cloud/media/presign-get", handler: (r, u) => mediaCloud.presignGetBatch(u, r) },
+
+  // Cloud-only: the chat panel's saved AI threads (local mode keeps them in
+  // the browser; cloud syncs them so chats follow the account).
+  { method: "GET", path: "/api/cut-cloud/projects/:id/chats", handler: (_r, u, p) => chatsCloud.list(u, p.id) },
+  { method: "PUT", path: "/api/cut-cloud/projects/:id/chats/:chatId", handler: (r, u, p) => chatsCloud.put(u, p.id, p.chatId, r) },
+  { method: "DELETE", path: "/api/cut-cloud/projects/:id/chats/:chatId", handler: (_r, u, p) => chatsCloud.remove(u, p.id, p.chatId) },
 
   { method: "GET", path: "/api/cut-cloud/library", handler: (_r, u) => libraryCloud.list(u) },
   { method: "POST", path: "/api/cut-cloud/library/presign", handler: (r, u) => libraryCloud.presign(u, r) },


### PR DESCRIPTION
One CutChatThread row per saved thread (client-minted id, slimmed
messages, provider session ids), with list/upsert/delete routes under
/api/cut-cloud/projects/:id/chats, userId-scoped like the rest of the
cloud surface. Deleting a project deletes its threads in the same
transaction.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S8sMw1zwQ5m6VEWkz36k6W