### PR TITLE
fix(site): convert overlay stills before fps duplicates them

### DIFF
--- a/site/src/cut/server/exportPipeline.ts
+++ b/site/src/cut/server/exportPipeline.ts
@@ -2028,7 +2028,7 @@ export async function runExport(
         filters.push(`[${onto}][oes${k}]overlay=0:0:eof_action=pass[${next}]`);
         return next;
       }
-      filters.push(`[${animIdx}:v]fps=${fps},format=yuva420p,setsar=1[oanim${k}]`);
+      filters.push(`[${animIdx}:v]format=yuva420p,fps=${fps},setsar=1[oanim${k}]`);
       filters.push(
         `[${onto}][oanim${k}]overlay=${num(o.x ?? 0)}:${num(o.y ?? 0)}:eof_action=pass[${next}]`
       );
@@ -2090,7 +2090,7 @@ export async function runExport(
   // costs one ffmpeg input per language instead of one per still. They sit
   // over every element and every effect.
   captionInputs.forEach((idx, k) => {
-    filters.push(`[${idx}:v]fps=${fps},format=yuva420p,setsar=1[caps${k}]`);
+    filters.push(`[${idx}:v]format=yuva420p,fps=${fps},setsar=1[caps${k}]`);
     filters.push(`[${vLabel}][caps${k}]overlay=0:0:eof_action=pass[vcaps${k}]`);
     vLabel = `vcaps${k}`;
   });


### PR DESCRIPTION
## What

The subtitle lane and the animation overlay lane in `site/src/cut/server/exportPipeline.ts` ran their filters as `fps` → `format`. Swapped to `format` → `fps`.

```diff
-[N:v]fps=${fps},format=yuva420p,setsar=1[caps${k}]
+[N:v]format=yuva420p,fps=${fps},setsar=1[caps${k}]
```

## Why

Those lanes are fed by the concat demuxer as a single still PNG. With `fps` first, the still is duplicated to the frame rate and `format` then converts each duplicate, allocating a fresh 1080×1920 yuva420p buffer (~4 MB) per frame — about 120 MB per second of timeline, queued in `overlay`'s framesync with no cap. Memory grows in proportion to export length until ffmpeg is killed. In a containerized deployment this surfaces as the process exiting with `code null` (signal termination); ffmpeg itself logs nothing.

With `format` first, the single still is converted once and `fps` duplicates references to it.

## Reproduction

Save as `repro.sh` in an empty directory and run `sh repro.sh`. It needs only ffmpeg.

```sh
#!/bin/sh
# Minimal reproduction of the overlay filter-order memory blowup.
set -e
FPS=30
DUR=20
W=1080
H=1920

# A single transparent PNG still, fed through the concat demuxer the way the
# export pipeline feeds subtitle/animation slideshows.
ffmpeg -y -v error -f lavfi -i "color=c=red@0.5:s=${W}x${H},format=rgba" -frames:v 1 still.png
printf "file '%s'\nduration %s\n" "$PWD/still.png" "$DUR" > list.txt
printf "file '%s'\n" "$PWD/still.png" >> list.txt

run() {
  order="$1"; out="$2"
  case "$order" in
    fps_first) chain="fps=${FPS},format=yuva420p,setsar=1" ;;
    format_first) chain="format=yuva420p,fps=${FPS},setsar=1" ;;
  esac
  set -- ffmpeg -y -v error \
    -f lavfi -i "color=c=black:s=${W}x${H}:r=${FPS}:d=${DUR}" \
    -f concat -safe 0 -i list.txt \
    -filter_complex "[1:v]${chain}[ov];[0:v][ov]overlay=0:0:eof_action=pass[v]" \
    -map "[v]" -t "$DUR" -f rawvideo -pix_fmt yuv420p "$out"
  case "$(uname)" in
    Darwin) /usr/bin/time -l "$@" 2>&1 | awk '/maximum resident set size/{printf "  max RSS %d MB\n", $1/1048576}' ;;
    *) /usr/bin/time -v "$@" 2>&1 | awk '/Maximum resident set size/{printf "  max RSS %d MB\n", $6/1024}' ;;
  esac
  if command -v sha256sum >/dev/null; then h=$(sha256sum "$out"); else h=$(shasum -a 256 "$out"); fi
  printf "  sha256 %s  bytes %s\n" "$(echo "$h" | cut -c1-16)" "$(wc -c < "$out" | tr -d ' ')"
}

echo "fps -> format"
run fps_first out_fps_first.raw
echo "format -> fps"
run format_first out_format_first.raw
```

Peak RSS comes from `/usr/bin/time -l` on macOS and `/usr/bin/time -v` on Linux; the script picks the right one by `uname`.

## Measurements

20 s, 1080×1920, one overlay still. macOS 15 (arm64), ffmpeg 9.0.1:

```
fps -> format
  max RSS 3083 MB
  sha256 a0e8190d1410a2d0  bytes 1866240000
format -> fps
  max RSS 100 MB
  sha256 a0e8190d1410a2d0  bytes 1866240000
```

97% less peak memory. The growth is linear in duration, so a 5-minute export on the old order needs roughly 15× that peak.

## No pixel regression

Both runs write rawvideo to disk and the script hashes it. The two outputs match on both the sha256 and the byte count (`a0e8190d1410a2d0…`, 1866240000 bytes) — the filter order changes allocation, not pixels.

## Tests

```
$ cd site && bun test src/cut/server/exportPipeline.test.ts src/cut/server/filterGraph.test.ts
 40 pass
 0 fail
 155 expect() calls
```

The wider `bun test src/cut/server` run has two failures in `cloud/transcribe.test.ts` and `jobs.test.ts` from a missing generated Prisma client (`@/generated/prisma/client`), present before this change.

The commit carries the ` [rebuild]` subject label per `AGENTS.md`, since `site/src/cut/server/` compiles into the Mac app engine.


---

## Output equivalence — checked beyond the hash

A matching hash on one clip is thin evidence, so I ran the two orders against
cases that stress the overlay path, and compared the decoded pixels rather than
just the file digest.

**Edge cases** (1080×1920, 30 fps, rawvideo out, sha256 of the full stream):

| case | what it exercises | fps → format | format → fps | same |
|---|---|---|---|---|
| basic | still spans the whole timeline | `84999158130bc785` | `84999158130bc785` | yes |
| overlay ends early | still runs out before the video — `eof_action=pass` | `35466ac447dead32` | `35466ac447dead32` | yes |
| slideshow | three stills with per-entry durations (a real caption track) | `9d67646c11fa9851` | `9d67646c11fa9851` | yes |
| fps mismatch | source 24 fps, output 30 fps | `693870e62749cae1` | `693870e62749cae1` | yes |
| opaque | fully opaque still, no alpha blending | `d20af99191aac907` | `d20af99191aac907` | yes |

**Pixel difference**, slideshow case, every frame:

```
ffmpeg -f rawvideo -pix_fmt yuv420p -s 1080x1920 -r 30 -i slideshow-fps_first.raw \
       -f rawvideo -pix_fmt yuv420p -s 1080x1920 -r 30 -i slideshow-format_first.raw \
       -filter_complex "[0:v][1:v]blend=all_mode=difference,format=gray,signalstats,\
metadata=print:key=lavfi.signalstats.YMAX:file=-" -f null -

→ 240 frames, YMAX = 0 on every one
```

Top row is the current order, middle row is the patched order, bottom row is
their difference — black means the frames are identical:

![frame comparison](https://raw.githubusercontent.com/taejs/Donkey/pr-evidence/evidence/frame-compare.png)
